### PR TITLE
Changed submodules from SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "3rdparty/json-parser"]
 	path = 3rdparty/json-parser
-	url = git@github.com:udp/json-parser.git
+	url = https://github.com/udp/json-parser.git
 [submodule "3rdparty/json-builder"]
 	path = 3rdparty/json-builder
-	url = git@github.com:udp/json-builder.git
+	url = https://github.com/udp/json-builder.git


### PR DESCRIPTION
This should allow anyone to clone the submodules with
`git submodule update --init --recursive`
even if they have not registered their SSH key onto GitHub