### PR TITLE
Build artifacts revision for release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         - platform: install
           plt_name: _pd
         - platform: install_core
-          plt_name: ""
+          plt_name: _lib
         - platform: install_pd
           plt_name: _pd
         - platform: install_max
@@ -80,7 +80,7 @@ jobs:
         - target: macosx
           dir: DSTDIR
         - platform: install_core
-          plt_name: ""
+          plt_name: _lib
         - platform: install_pd
           plt_name: _pd
         - platform: install_max
@@ -128,10 +128,10 @@ jobs:
     strategy:
       matrix:
         target: [linux, win32, win64, macosx]
-        plt_name: ["", _pd, _max]
+        plt_name: ["_lib", _pd, _max]
         exclude:
         - target: linux
-          plt_name: ""
+          plt_name: _lib
         - target: linux
           plt_name: _max
         - target: win64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         prerelease: ${{ contains( github.ref , 'dev' ) }}
     - name: Get the version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v}
 
   release-upload:
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,18 +18,10 @@ jobs:
     strategy:
       matrix:
         target: [linux, win32, win64]
-        platform: [install, install_core, install_max, install_pd]
+        platform: [install_core, install_max, install_pd]
         exclude:
         - target: linux
-          platform: install_core
-        - target: linux
           platform: install_max
-        - target: linux
-          platform: install_pd
-        - target: win32
-          platform: install
-        - target: win64
-          platform: install
         - target: win64
           platform: install_pd
         include:
@@ -39,8 +31,6 @@ jobs:
           dir: DSTDIR
         - target: win64
           dir: DSTDIR
-        - platform: install
-          plt_name: _pd
         - platform: install_core
           plt_name: _lib
         - platform: install_pd
@@ -66,16 +56,13 @@ jobs:
 
   # Cannot be run in the previous matrix because there is no way (for now) to specify not to use a container for macos
   # https://github.community/t/run-matrix-job-on-macos-and-on-ubuntu-in-container/16359/3
-  # Job definiton is ready for merge in case the option is impelemented
+  # Job definiton is ready for merge in case the option is implemented
   build-macos:
     runs-on: macos-latest
     strategy:
       matrix:
         target: [macosx]
-        platform: [install, install_core, install_max, install_pd]
-        exclude:
-        - target: macosx
-          platform: install
+        platform: [install_core, install_max, install_pd]
         include:
         - target: macosx
           dir: DSTDIR
@@ -130,8 +117,6 @@ jobs:
         target: [linux, win32, win64, macosx]
         plt_name: ["_lib", _pd, _max]
         exclude:
-        - target: linux
-          plt_name: _lib
         - target: linux
           plt_name: _max
         - target: win64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,6 @@ jobs:
         - target: win64
           platform: install_pd
         include:
-        - target: linux
-          dir: PREFIX
-        - target: win32
-          dir: DSTDIR
-        - target: win64
-          dir: DSTDIR
         - platform: install_core
           plt_name: _lib
         - platform: install_pd
@@ -47,7 +41,7 @@ jobs:
     - name: Prepare package directory
       run: mkdir SoundDesignToolkit
     - name: Package
-      run: cd build/${{ matrix.target }} && make ${{ matrix.platform }} ${{ matrix.dir }}=../../SoundDesignToolkit
+      run: cd build/${{ matrix.target }} && make ${{ matrix.platform }} DSTDIR=../../SoundDesignToolkit
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
@@ -64,8 +58,6 @@ jobs:
         target: [macosx]
         platform: [install_core, install_max, install_pd]
         include:
-        - target: macosx
-          dir: DSTDIR
         - platform: install_core
           plt_name: _lib
         - platform: install_pd
@@ -82,7 +74,7 @@ jobs:
     - name: Prepare package directory
       run: mkdir SoundDesignToolkit
     - name: Package
-      run: cd build/${{ matrix.target }} && make ${{ matrix.platform }} ${{ matrix.dir }}=../../SoundDesignToolkit
+      run: cd build/${{ matrix.target }} && make ${{ matrix.platform }} DSTDIR=../../SoundDesignToolkit
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ recommended) or Cygwin (http://www.cygwin.com).
 commands to compile the software in all its flavors (Max package, Pd library,
 Shared DLL):
 ```
-        cd build/win32 (or cd build/win64 for the x64 version)
-        make
+	cd build/win32 (or cd build/win64 for the x64 version)
+	make
 ```
 2. Install the desired products. The script will install the desired product in
 the given destination ``<path>``, creating a ``SDT`` subfolder:
@@ -104,7 +104,7 @@ the given destination ``<path>``, creating a ``SDT`` subfolder:
 ```
 3. To clean the source directories after compilation:
 ```
-        make clean
+	make clean
 ```
 
 #### Linux
@@ -113,14 +113,14 @@ the given destination ``<path>``, creating a ``SDT`` subfolder:
 	cd build/linux
 	make
 ```
-2. Install the SDT: By default, the building environment will install a shared
-library in ``/usr/lib`` and a collection of PureData externals and patches in
-``/usr/lib/pd/extras/SDT``.
+2. Install the desired products. By default, the building environment will
+install a shared library in ``/usr/lib`` and a collection of PureData externals
+and patches in ``/usr/lib/pd/extras/SDT``.
 Root privileges may be required to access the default install path. If you want
-to change the install path, provide a ``PREFIX`` argument:
-```       
-	make install
-	make install PREFIX=<path>
+to change the install path, provide a ``DSTDIR`` argument:
+```
+	make install_pd DSTDIR=<path>
+	make install_core DSTDIR=<path>
 ```
 3. To clean the source directories after compilation:
 ```

--- a/build/linux/Makefile
+++ b/build/linux/Makefile
@@ -6,7 +6,7 @@ LDFLAGS=-shared
 ROOT=../..
 SRCDIR=$(ROOT)/src
 THIRDPDIR=$(ROOT)/3rdparty
-PREFIX=/usr
+DSTDIR=/usr
 SDTPATH=SDT
 
 SDTDIR=$(SRCDIR)/SDT
@@ -68,22 +68,22 @@ $(JSONDIRB)/%.o: $(JSONDIRB)/%.c
 	$(CC) $(CFLAGS) $(INCLUDE_JSON) -c $< -o $@
 
 install_core:
-	mkdir -p $(PREFIX)/include/$(SDTPATH)
-	mkdir -p $(PREFIX)/lib
-	cp -a $(SDTDIR)/libSDT.so $(PREFIX)/lib
-	cp -a $(SDTDIR)/*.h $(PREFIX)/include/$(SDTPATH)
-	cp -a $(JSONDIRP)/*.h $(PREFIX)/include/$(SDTPATH)
-	cp -a $(JSONDIRB)/*.h $(PREFIX)/include/$(SDTPATH)
+	mkdir -p $(DSTDIR)/include/$(SDTPATH)
+	mkdir -p $(DSTDIR)/lib
+	cp -a $(SDTDIR)/libSDT.so $(DSTDIR)/lib
+	cp -a $(SDTDIR)/*.h $(DSTDIR)/include/$(SDTPATH)
+	cp -a $(JSONDIRP)/*.h $(DSTDIR)/include/$(SDTPATH)
+	cp -a $(JSONDIRB)/*.h $(DSTDIR)/include/$(SDTPATH)
 
 install_pd: install_core
-	mkdir -p $(PREFIX)/lib/pd/extra/$(SDTPATH)
-	cp -a $(PDDIR)/*.pd_linux $(PREFIX)/lib/pd/extra/$(SDTPATH)
-	cp -a ../../Pd/* $(PREFIX)/lib/pd/extra/$(SDTPATH)
+	mkdir -p $(DSTDIR)/lib/pd/extra/$(SDTPATH)
+	cp -a $(PDDIR)/*.pd_linux $(DSTDIR)/lib/pd/extra/$(SDTPATH)
+	cp -a ../../Pd/* $(DSTDIR)/lib/pd/extra/$(SDTPATH)
 
 uninstall:
-	rm -f $(PREFIX)/lib/libSDT.so
-	rm -rf $(PREFIX)/lib/pd/extra/$(SDTPATH)
-	rm -rf $(PREFIX)/include/$(SDTPATH)
+	rm -f $(DSTDIR)/lib/libSDT.so
+	rm -rf $(DSTDIR)/lib/pd/extra/$(SDTPATH)
+	rm -rf $(DSTDIR)/include/$(SDTPATH)
 
 clean:
 	rm -rf $(SDTDIR)/*.so

--- a/build/linux/Makefile
+++ b/build/linux/Makefile
@@ -67,16 +67,18 @@ $(JSONDIRP)/%.o: $(JSONDIRP)/%.c
 $(JSONDIRB)/%.o: $(JSONDIRB)/%.c
 	$(CC) $(CFLAGS) $(INCLUDE_JSON) -c $< -o $@
 
-
-install:
-	mkdir -p $(PREFIX)/lib/pd/extra/$(SDTPATH)
+install_core:
 	mkdir -p $(PREFIX)/include/$(SDTPATH)
+	mkdir -p $(PREFIX)/lib
 	cp -a $(SDTDIR)/libSDT.so $(PREFIX)/lib
-	cp -a $(PDDIR)/*.pd_linux $(PREFIX)/lib/pd/extra/$(SDTPATH)
-	cp -a ../../Pd/* $(PREFIX)/lib/pd/extra/$(SDTPATH)
 	cp -a $(SDTDIR)/*.h $(PREFIX)/include/$(SDTPATH)
 	cp -a $(JSONDIRP)/*.h $(PREFIX)/include/$(SDTPATH)
 	cp -a $(JSONDIRB)/*.h $(PREFIX)/include/$(SDTPATH)
+
+install_pd: install_core
+	mkdir -p $(PREFIX)/lib/pd/extra/$(SDTPATH)
+	cp -a $(PDDIR)/*.pd_linux $(PREFIX)/lib/pd/extra/$(SDTPATH)
+	cp -a ../../Pd/* $(PREFIX)/lib/pd/extra/$(SDTPATH)
 
 uninstall:
 	rm -f $(PREFIX)/lib/libSDT.so


### PR DESCRIPTION
Revised build artifacts for releases
 - removed the leading `v` of version tags from asset names
 - added `lib` to core library assets
 - added core library asset for Linux

Consistency changes
 - separated `core` and `pd` installation targets for Linux
 - changed `PREFIX` variable to `DSTDIR` in Linux makefile