### PR TITLE
Fix: https://github.com/SkAT-VG/SDT/issues/17

### DIFF
--- a/build/macosx/Makefile
+++ b/build/macosx/Makefile
@@ -72,7 +72,7 @@ $(MAXDIR)/%.o: $(MAXDIR)/%.c
 	-F$(SDTDIR) -include $(MAXSDKDIR)/max-includes/macho-prefix.pch -c $< -o $@
 
 pd: $(SDTOBJS) $(PDOBJS)
-	$(CC) $(LDFLAGS) -undefined dynamic_lookup $(SDTOBJS) $(PDOBJS) -o $(PDDIR)/SDT.pd_darwin
+	$(CC) $(LDFLAGS) -undefined dynamic_lookup $(JSONOBJS) $(SDTOBJS) $(PDOBJS) -o $(PDDIR)/SDT.pd_darwin
 
 $(PDDIR)/%.o: $(PDDIR)/%.c
 	$(CC) $(CFLAGS) -I$(SRCDIR) -I$(PDSDKDIR) $(INCLUDE_JSON) -F$(SDTDIR) -c $< -o $@

--- a/src/SDT/SDTCommon.h
+++ b/src/SDT/SDTCommon.h
@@ -76,7 +76,7 @@ SDTCommon.h should always be included when using other SDT modules.
 #define SDT_COMMON_H
 
 /** @brief SDT version number */
-#define SDT_ver          080
+#define SDT_ver          081
 /** @brief Value of Pi */
 #define SDT_PI           3.141592653589793
 /** @brief Value of 2 * Pi */


### PR DESCRIPTION
Including JSON object files in MacOS Pd dynamic library

To verify that the issue (https://github.com/SkAT-VG/SDT/issues/17) has been solved, download [SDT_macosx_pd_0.96-dev-080.zip](https://github.com/ChromaticIsobar/SDT/releases/download/v080-Max3.0-Pd0.96-dev/SDT_macosx_pd_0.96-dev-080.zip)