### PR TITLE
Refactored Makefiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ shared core library / Apple framework are provided as release assets of this
 repository at: https://github.com/SkAT-VG/SDT/releases
 Unpack the appropriate .zip file for your operating system and target platform
 into the desired destination folder.
-Linux users will need to copy the shared core library `libSDT.so` to `/usr/lib` (root privileges may be required).
 
 ### Compiling from source code
 Users may as well build a Max *package*, Pd *library*, shared core library /

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ commands to compile the software in all its flavors (Max *package*, Pd
 	cd build/win32 (or cd build/win64 for the x64 version)
 	make
 ```
-2. Install one or more products: The provided scripts will install the selected
-products in the given destination `<path>`, creating a `SDT` subfolder:
+2. Install one or more products. The provided scripts will install the selected
+products in the given destination `<path>`, in a subfolder (`SDT` for Pd or DLL
+and `Sound Design Toolkit` for Max):
 ```
 	make install_max DSTDIR=<path>
 	make install_pd DSTDIR=<path> (only for 32 bit)
@@ -103,6 +104,14 @@ products in the given destination `<path>`, creating a `SDT` subfolder:
 3. To clean the source directories after compilation:
 ```
 	make clean
+```
+4. To uninstall one or more products, run the corresponding command.
+Please provide the same `<path>` specified at installation (the parent
+folder of the SDT folder)
+```
+	make uninstall_max DSTDIR=<path> (only for 32 bit)
+	make uninstall_pd DSTDIR=<path> (only for 32 bit)
+	make uninstall_core DSTDIR=<path> (only for 32 bit)
 ```
 
 #### Linux

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ and `Sound Design Toolkit` for Max):
 Please provide the same `<path>` specified at installation (the parent
 folder of the SDT folder)
 ```
-	make uninstall_max DSTDIR=<path> (only for 32 bit)
+	make uninstall_max DSTDIR=<path>
 	make uninstall_pd DSTDIR=<path> (only for 32 bit)
-	make uninstall_core DSTDIR=<path> (only for 32 bit)
+	make uninstall_core DSTDIR=<path>
 ```
 
 #### Linux

--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ folder of the SDT folder)
 	make
 ```
 2. Install one or more products. By default, the building environment will
-install the SDT shared core library in `/usr` and the Pd *library* in
-`/usr/lib/pd/extras`. Root privileges may be required to access the
-default install path.
+install the SDT shared library in `/usr/lib` and the headers in `/usr/include`
+(`DSTDIR=/usr`). The default path for the Pd *library* is `/usr/lib/pd/extras`.
+Root privileges may be required to access the default install path.
 If you want to change the install path, provide a `DSTDIR` argument:
 ```
 	make install_pd DSTDIR=<path>

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ products in the given destination `<path>`, creating a `SDT` subfolder:
 ```
 	make clean
 ```
+4. To uninstall one or more products, run the corresponding command.
+Please provide the same `<path>` specified at installation (the parent
+folder of the SDT folder)
+```
+	make uninstall_max DSTDIR=<path>
+	make uninstall_pd DSTDIR=<path>
+	make uninstall_core DSTDIR=<path>
+```
 
 #### Windows
 To compile the SDT under Windows, you need a distribution of the GNU C Compiler

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ products in the given destination `<path>`, creating a `SDT` subfolder:
 	cd build/linux
 	make
 ```
-2. Install one or more products: By default, the building environment will
-install the SDT shared core library in `/usr/lib` and the Pd *library* in
-`/usr/lib/pd/extras/SDT`. Root privileges may be required to access the
+2. Install one or more products. By default, the building environment will
+install the SDT shared core library in `/usr` and the Pd *library* in
+`/usr/lib/pd/extras`. Root privileges may be required to access the
 default install path.
 If you want to change the install path, provide a `DSTDIR` argument:
 ```
@@ -124,7 +124,13 @@ If you want to change the install path, provide a `DSTDIR` argument:
 ```
 	make clean
 ```
-
+4. To uninstall one or more products, run the corresponding command. Root
+privileges may be required to access the default install path. If you
+installed SDT under a custom path, please provide a `DSTDIR` argument:
+```
+	make uninstall_pd DSTDIR=<path>
+	make uninstall_core DSTDIR=<path>
+```
 
 ## Acknowledgements
 The SDT was developed through the years with the contribution of the following

--- a/build/linux/Makefile
+++ b/build/linux/Makefile
@@ -6,7 +6,7 @@ LDFLAGS=-shared
 ROOT=../..
 SRCDIR=$(ROOT)/src
 THIRDPDIR=$(ROOT)/3rdparty
-DSTDIR=/usr
+# DSTDIR=/usr
 SDTPATH=SDT
 
 SDTDIR=$(SRCDIR)/SDT
@@ -34,9 +34,9 @@ OSCDOCRST=$(OSCDOCSOURCEDIR)/ordinary_classes.rst
 INCLUDE_JSON=-I$(JSONDIRP) -I$(JSONDIRB)
 INCLUDE_SDT=-I$(SDTDIR)
 
-all: sdt pd
+all: core pd
 
-.PHONY: sdt pd oscdoc_%
+.PHONY: core pd oscdoc_%
 
 oscdoc_%: $(OSCDOCRST)
 	cd $(OSCDOCDIR) && make $(@:oscdoc_%=%)
@@ -47,13 +47,13 @@ $(OSCDOCRST): $(OSCDOCGEN)
 $(OSCDOCGEN): $(OSCDOCGEN).c
 	$(CC) $(CFLAGS) -I$(SRCDIR) $(INCLUDE_SDT) $(INCLUDE_JSON) $< -o $@
 
-pd: sdt $(PDOBJS)
-	$(CC) $(LDFLAGS) -L$(SDTDIR) $(PDOBJS) $(INCLUDE_JSON) -o $(PDDIR)/SDT.pd_linux -lc -lm -lSDT
+pd: core $(PDOBJS)
+	$(CC) $(LDFLAGS) $(JSONOBJS) $(SDTOBJS) $(PDOBJS) -o $(PDDIR)/SDT.pd_linux
 
 $(PDDIR)/%.o: $(PDDIR)/%.c
 	$(CC) $(CFLAGS) -I$(SRCDIR) $(INCLUDE_JSON) -c $< -o $@
 
-sdt: $(SDTOBJS) json
+core: $(SDTOBJS) json
 	$(CC) $(LDFLAGS) $(SDTOBJS) $(JSONOBJS) $(INCLUDE_JSON) -o $(SDTDIR)/libSDT.so -lc -lm
 
 $(SDTDIR)/%.o: $(SDTDIR)/%.c
@@ -68,27 +68,61 @@ $(JSONDIRB)/%.o: $(JSONDIRB)/%.c
 	$(CC) $(CFLAGS) $(INCLUDE_JSON) -c $< -o $@
 
 install_core:
-	mkdir -p $(DSTDIR)/include/$(SDTPATH)
-	mkdir -p $(DSTDIR)/lib
-	cp -a $(SDTDIR)/libSDT.so $(DSTDIR)/lib
-	cp -a $(SDTDIR)/*.h $(DSTDIR)/include/$(SDTPATH)
-	cp -a $(JSONDIRP)/*.h $(DSTDIR)/include/$(SDTPATH)
-	cp -a $(JSONDIRB)/*.h $(DSTDIR)/include/$(SDTPATH)
+	$(eval DSTDIR ?= "/usr")
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make install_core DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		mkdir -p $(DSTDIR)/include/$(SDTPATH) && \
+		mkdir -p $(DSTDIR)/lib && \
+		cp -a $(SDTDIR)/libSDT.so $(DSTDIR)/lib && \
+		cp -a $(SDTDIR)/*.h $(DSTDIR)/include/$(SDTPATH) && \
+		cp -a $(JSONDIRP)/*.h $(DSTDIR)/include/$(SDTPATH) && \
+		cp -a $(JSONDIRB)/*.h $(DSTDIR)/include/$(SDTPATH) && \
+		echo "Sound Design Toolkit 'Core Library' installed in '${DSTDIR}'"; \
+  fi
 
-install_pd: install_core
-	mkdir -p $(DSTDIR)/lib/pd/extra/$(SDTPATH)
-	cp -a $(PDDIR)/*.pd_linux $(DSTDIR)/lib/pd/extra/$(SDTPATH)
-	cp -a ../../Pd/* $(DSTDIR)/lib/pd/extra/$(SDTPATH)
+uninstall_core:
+	$(eval DSTDIR ?= "/usr")
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make uninstall_core DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		rm -rf "$(DSTDIR)/include/$(SDTPATH)" && \
+		rm -f "$(DSTDIR)/lib/libSDT.so" && \
+		echo "Sound Design Toolkit 'Core Library' removed from '${DSTDIR}'"; \
+  fi
 
-uninstall:
-	rm -f $(DSTDIR)/lib/libSDT.so
-	rm -rf $(DSTDIR)/lib/pd/extra/$(SDTPATH)
-	rm -rf $(DSTDIR)/include/$(SDTPATH)
+install_pd:
+	$(eval DSTDIR ?= "/usr/lib/pd/extra")
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make install_pd DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		mkdir -p "${DSTDIR}/${SDTPATH}" && \
+		cp -a ../../Pd/* "${DSTDIR}/${SDTPATH}" && \
+		cp -a $(PDDIR)/*.pd_linux "${DSTDIR}/${SDTPATH}" && \
+		echo "Sound Design Toolkit for PureData installed in '${DSTDIR}/${SDTPATH}'"; \
+	fi
+
+uninstall_pd:
+	$(eval DSTDIR ?= "/usr/lib/pd/extra")
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make uninstall_pd DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		rm -rf "${DSTDIR}/${SDTPATH}" && \
+		echo "Sound Design Toolkit for PureData removed from '${DSTDIR}/${SDTPATH}"; \
+	fi
 
 clean:
-	rm -rf $(SDTDIR)/*.so
-	rm -rf $(SDTDIR)/*.o
-	rm -rf $(PDDIR)/*.pd_linux
-	rm -rf $(PDDIR)/*.o
-	rm -rf $(JSONDIRP)/*.o
-	rm -rf $(JSONDIRB)/*.o
+	rm -rf "$(SDTDIR)/"*.so
+	rm -rf "$(SDTDIR)/"*.o
+	rm -rf "$(PDDIR)/"*.pd_linux
+	rm -rf "$(PDDIR)/"*.o
+	rm -rf "$(JSONDIRP)/"*.o
+	rm -rf "$(JSONDIRB)/"*.o

--- a/build/macosx/Makefile
+++ b/build/macosx/Makefile
@@ -107,36 +107,69 @@ $(JSONDIRB)/%.o: $(JSONDIRB)/%.c
 	$(CC) $(CFLAGS) $(INCLUDE_JSON) -c $< -o $@
 
 install_max:
-	@if [ -z "$(DSTDIR)" ]; \
-	then echo "Usage: make install_max DSTDIR=<installation_path>"; \
-	elif [ ! -d "$(DSTDIR)" ]; \
-	then echo "Error: installation path does not exist or is not a directory"; \
-	else mkdir -p "${DSTDIR}/Sound Design Toolkit/"{externals,support} && \
-	     cp -a $(MAXPACKDIR)/* "${DSTDIR}/Sound Design Toolkit/" && \
-	     cp -a $(SDTDIR)/SDT.framework "${DSTDIR}/Sound Design Toolkit/support" && \
-	     cp -a $(MAXDIR)/*.mxo "${DSTDIR}/Sound Design Toolkit/externals" && \
-	     echo "Sound Design Toolkit 'package for Max' installed in $(DSTDIR)"; \
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make install_max DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		mkdir -p "${DSTDIR}/Sound Design Toolkit/"{externals,support} && \
+		cp -a $(MAXPACKDIR)/* "${DSTDIR}/Sound Design Toolkit/" && \
+		cp -a $(SDTDIR)/SDT.framework "${DSTDIR}/Sound Design Toolkit/support" && \
+		cp -a $(MAXDIR)/*.mxo "${DSTDIR}/Sound Design Toolkit/externals" && \
+		echo "Sound Design Toolkit package for Max installed in '$(DSTDIR)/Sound Design Toolkit'"; \
+	fi
+
+uninstall_max:
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make uninstall_max DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		rm -rf "${DSTDIR}/Sound Design Toolkit/" && \
+		echo "Sound Design Toolkit package for Max removed from '${DSTDIR}/Sound Design Toolkit'"; \
 	fi
 
 install_pd:
-	@if [ -z "$(DSTDIR)" ]; \
-        then echo "Usage: make install_pd DSTDIR=<installation_path>"; \
-        elif [ ! -d "$(DSTDIR)" ]; \
-        then echo "Error: installation path does not exist or is not a directory"; \
-	else mkdir -p "$(DSTDIR)"/SDT && \
-	     cp -a ../../Pd/* "$(DSTDIR)"/SDT && \
-	     cp -a $(PDDIR)/*.pd_darwin "$(DSTDIR)"/SDT && \
-	     echo "Sound Design Toolkit for PureData installed in $(DSTDIR)"; \
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make install_pd DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		mkdir -p "$(DSTDIR)"/SDT && \
+		cp -a ../../Pd/* "$(DSTDIR)"/SDT && \
+		cp -a $(PDDIR)/*.pd_darwin "$(DSTDIR)"/SDT && \
+		echo "Sound Design Toolkit for PureData installed in '$(DSTDIR)/SDT'"; \
+	fi
+
+uninstall_pd:
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make uninstall_pd DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ];  then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		rm -rf "$(DSTDIR)"/SDT && \
+		echo "Sound Design Toolkit for Pure Data removed from '$(DSTDIR)/SDT'"; \
 	fi
 
 install_core:
-	@if [ -z "$(DSTDIR)" ]; \
-		then echo "Usage: make install_core DSTDIR=<installation_path>"; \
-		elif [ ! -d "$(DSTDIR)" ]; \
-		then echo "Error: installation path does not exist or is not a directory"; \
-	else mkdir -p "$(DSTDIR)"/SDT && \
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make install_core DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		mkdir -p "$(DSTDIR)"/SDT && \
 		cp -a $(SDTDIR)/SDT.framework "$(DSTDIR)"/SDT && \
-		echo "Sound Design Toolkit 'core library' installed in $(DSTDIR)"; \
+		echo "Sound Design Toolkit 'Core library' installed in '$(DSTDIR)/SDT'"; \
+	fi
+
+uninstall_core:
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make uninstall_core DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		rm -rf "$(DSTDIR)"/SDT && \
+		echo "Sound Design Toolkit 'Core Library' removed from '$(DSTDIR)/SDT'"; \
 	fi
 
 clean:

--- a/build/macosx/Makefile
+++ b/build/macosx/Makefile
@@ -71,7 +71,7 @@ $(MAXDIR)/%.o: $(MAXDIR)/%.c
 	-F$(MAXSDKDIR)/max-includes -F$(MAXSDKDIR)/msp-includes -F$(MAXSDKDIR)/jit-includes \
 	-F$(SDTDIR) -include $(MAXSDKDIR)/max-includes/macho-prefix.pch -c $< -o $@
 
-pd: $(SDTOBJS) $(PDOBJS)
+pd: $(JSONOBJS) $(SDTOBJS) $(PDOBJS)
 	$(CC) $(LDFLAGS) -undefined dynamic_lookup $(JSONOBJS) $(SDTOBJS) $(PDOBJS) -o $(PDDIR)/SDT.pd_darwin
 
 $(PDDIR)/%.o: $(PDDIR)/%.c

--- a/build/win32/Makefile
+++ b/build/win32/Makefile
@@ -40,7 +40,7 @@ JSONOBJS=$(JSONOBJP) $(JSONOBJB)
 
 all: core max pd
 
-pd: $(SDTOBJS) $(PDOBJS)
+pd: $(SDTOBJS) $(PDOBJS) $(JSONOBJS)
 	$(CC) $(LDFLAGS) -L$(PDSDKDIR) $(JSONOBJS) $(SDTOBJS) $(PDOBJS) -o $(PDDIR)/SDT.dll -lpd
 
 $(PDDIR)/%.o: $(PDDIR)/%.c

--- a/build/win32/Makefile
+++ b/build/win32/Makefile
@@ -83,45 +83,83 @@ $(JSONDIRB)/%.o: $(JSONDIRB)/%.c
 	$(CC) $(CFLAGS) $(INCLUDE_JSON) -c $< -o $@
 
 install_max:
-	@if [ -z "$(DSTDIR)" ]; \
-	then echo "Usage: make install_max DSTDIR=<installation_path>"; \
-	elif [ ! -d "$(DSTDIR)" ]; \
-	then echo "Error: installation path does not exist or is not a directory"; \
-	else mkdir -p "${DSTDIR}/Sound Design Toolkit/"{externals,support} && \
-	     cp -a $(MAXPACKDIR)/* "${DSTDIR}/Sound Design Toolkit/" && \
-	     cp -a $(SDTDIR)/libSDT.dll "${DSTDIR}/Sound Design Toolkit/support" && \
-	     cp -a $(MAXDIR)/*.mxe "${DSTDIR}/Sound Design Toolkit/externals" && \
-	     echo "Sound Design Toolkit 'package for Max' installed in $(DSTDIR)"; \
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make install_max DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		mkdir -p "${DSTDIR}/Sound Design Toolkit/"{externals,support} && \
+		cp -a $(MAXPACKDIR)/* "${DSTDIR}/Sound Design Toolkit/" && \
+		cp -a $(SDTDIR)/libSDT.dll "${DSTDIR}/Sound Design Toolkit/support" && \
+		cp -a $(MAXDIR)/*.mxe "${DSTDIR}/Sound Design Toolkit/externals" && \
+		echo "Sound Design Toolkit package for Max installed in '${DSTDIR}/Sound Design Toolkit'"; \
+	fi
+
+uninstall_max:
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make uninstall_max DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		rm -rf "${DSTDIR}/Sound Design Toolkit/" && \
+		echo "Sound Design Toolkit package for Max removed from '${DSTDIR}/Sound Design Toolkit'"; \
 	fi
 
 install_pd:
-	@if [ -z "$(DSTDIR)" ]; \
-        then echo "Usage: make install_pd DSTDIR=<installation_path>"; \
-        elif [ ! -d "$(DSTDIR)" ]; \
-        then echo "Error: installation path does not exist or is not a directory"; \
-	else mkdir -p "$(DSTDIR)"/SDT && \
-	     cp -a ../../Pd/* "$(DSTDIR)"/SDT && \
-	     cp -a $(PDDIR)/SDT.dll "$(DSTDIR)"/SDT && \
-	     echo "Sound Design Toolkit for Pure Data installed in $(DSTDIR)"; \
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make install_pd DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ];  then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		mkdir -p "$(DSTDIR)"/SDT && \
+		cp -a ../../Pd/* "$(DSTDIR)"/SDT && \
+		cp -a $(PDDIR)/SDT.dll "$(DSTDIR)"/SDT && \
+		echo "Sound Design Toolkit for Pure Data installed in '$(DSTDIR)/SDT'"; \
+	fi
+
+uninstall_pd:
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make uninstall_pd DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ];  then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		rm -rf "$(DSTDIR)"/SDT && \
+		echo "Sound Design Toolkit for Pure Data removed from '$(DSTDIR)/SDT'"; \
 	fi
 
 install_core:
-	@if [ -z "$(DSTDIR)" ]; \
-		then echo "Usage: make install_core DSTDIR=<installation_path>"; \
-		elif [ ! -d "$(DSTDIR)" ]; \
-		then echo "Error: installation path does not exist or is not a directory"; \
-	else mkdir -p "$(DSTDIR)"/SDT && \
-		cp -a $(SDTDIR)/libSDT.dll "$(DSTDIR)"/SDT && \
-		echo "Sound Design Toolkit 'core library' installed in $(DSTDIR)"; \
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make install_core DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		mkdir -p "$(DSTDIR)"/include/SDT && \
+		mkdir -p "$(DSTDIR)"/lib && \
+		cp -a $(SDTDIR)/libSDT.dll "$(DSTDIR)"/lib && \
+		cp -a $(SDTDIR)/*.h $(DSTDIR)/include/SDT && \
+		cp -a $(JSONDIRP)/*.h $(DSTDIR)/include/SDT && \
+		cp -a $(JSONDIRB)/*.h $(DSTDIR)/include/SDT && \
+		echo "Sound Design Toolkit 'Core Library' installed in '$(DSTDIR)'"; \
+	fi
+
+uninstall_core:
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make uninstall_core DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		rm -rf "$(DSTDIR)"/include/SDT && \
+		rm -f "$(DSTDIR)"/lib/libSDT.dll && \
+		echo "Sound Design Toolkit 'Core Library' removed from '$(DSTDIR)'"; \
 	fi
 
 clean:
-	rm -rf $(SDTDIR)/libSDT.dll
-	rm -rf $(SDTDIR)/*.o
-	rm -rf $(MAXDIR)/*.mxe
-	rm -rf $(MAXDIR)/*.def
-	rm -rf $(MAXDIR)/*.o
-	rm -rf $(PDDIR)/*.dll
-	rm -rf $(PDDIR)/*.o
-	rm -rf $(JSONDIRP)/*.o
-	rm -rf $(JSONDIRB)/*.o
+	rm -rf "$(SDTDIR)/"libSDT.dll
+	rm -rf "$(SDTDIR)/"*.o
+	rm -rf "$(MAXDIR)/"*.mxe
+	rm -rf "$(MAXDIR)/"*.def
+	rm -rf "$(MAXDIR)/"*.o
+	rm -rf "$(PDDIR)/"*.dll
+	rm -rf "$(PDDIR)/"*.o
+	rm -rf "$(JSONDIRP)/"*.o
+	rm -rf "$(JSONDIRB)/"*.o

--- a/build/win64/Makefile
+++ b/build/win64/Makefile
@@ -40,7 +40,7 @@ $(MAXDIR)/%.mxe64: $(MAXDIR)/%.o
 	cp Info.def $(MAXDIR)/$(EXTNAME).def
 	sed -i $(MAXDIR)/$(EXTNAME).def -e s/\$${PRODUCT_NAME}/$(EXTNAME)/g
 	$(CC) $(LDFLAGS) -L$(MAXSDKDIR)/max-includes/x64 -L$(MAXSDKDIR)/msp-includes/x64 -L$(MAXSDKDIR)/jit-includes/x64 -L$(SDTDIR) \
-	$< $(MAXDIR)/$(EXTNAME).def -o $@ $(MAXDIR)/SDT_fileusage.o -lMaxAPI -lMaxAudio -lSDT
+	$< $(MAXDIR)/$(EXTNAME).def -o $@ $(MAXDIR)/SDT_fileusage.o -lMaxAPI -lMaxAudio -lSDT64
 
 $(MAXDIR)/%.o: $(MAXDIR)/%.c
 	$(CC) $(CFLAGS) -DDENORM_WANT_FIX=1 -DNO_TRANSLATION_SUPPORT=1 -DC74_NO_DEPRECATION \
@@ -56,7 +56,7 @@ fileusage:
 	-I$(SRCDIR) -c $(MAXDIR)/SDT_fileusage/SDT_fileusage.c -o $(MAXDIR)/SDT_fileusage.o
 
 core: $(SDTOBJS) json
-	$(CC) $(LDFLAGS) $(SDTOBJS) $(JSONOBJS) -o $(SDTDIR)/libSDT.dll
+	$(CC) $(LDFLAGS) $(SDTOBJS) $(JSONOBJS) -o $(SDTDIR)/libSDT64.dll
 
 $(SDTDIR)/%.o: $(SDTDIR)/%.c
 	$(CC) $(CFLAGS) $(INCLUDE_JSON) -c $< -o $@
@@ -77,7 +77,7 @@ install_max:
 	else \
 		mkdir -p "${DSTDIR}/Sound Design Toolkit/"{externals,support} && \
 		cp -a $(MAXPACKDIR)/* "${DSTDIR}/Sound Design Toolkit/" && \
-		cp -a $(SDTDIR)/libSDT.dll "${DSTDIR}/Sound Design Toolkit/support" && \
+		cp -a $(SDTDIR)/libSDT64.dll "${DSTDIR}/Sound Design Toolkit/support" && \
 		cp -a $(MAXDIR)/*.mxe64 "${DSTDIR}/Sound Design Toolkit/externals" && \
 		echo "Sound Design Toolkit package for Max installed in '${DSTDIR}/Sound Design Toolkit'"; \
 	fi
@@ -100,7 +100,7 @@ install_core:
 	else \
 		mkdir -p "$(DSTDIR)"/include/SDT && \
 		mkdir -p "$(DSTDIR)"/lib && \
-		cp -a $(SDTDIR)/libSDT.dll "$(DSTDIR)"/lib && \
+		cp -a $(SDTDIR)/libSDT64.dll "$(DSTDIR)"/lib && \
 		cp -a $(SDTDIR)/*.h $(DSTDIR)/include/SDT && \
 		cp -a $(JSONDIRP)/*.h $(DSTDIR)/include/SDT && \
 		cp -a $(JSONDIRB)/*.h $(DSTDIR)/include/SDT && \
@@ -114,12 +114,12 @@ uninstall_core:
 		echo "Error: installation path does not exist or is not a directory"; \
 	else \
 		rm -rf "$(DSTDIR)"/include/SDT && \
-		rm -f "$(DSTDIR)"/lib/libSDT.dll && \
+		rm -f "$(DSTDIR)"/lib/libSDT64.dll && \
 		echo "Sound Design Toolkit 'Core Library' removed from '$(DSTDIR)/SDT'"; \
 	fi
 
 clean:
-	rm -rf $(SDTDIR)/libSDT.dll
+	rm -rf $(SDTDIR)/libSDT64.dll
 	rm -rf $(SDTDIR)/*.o
 	rm -rf $(MAXDIR)/*.mxe64
 	rm -rf $(MAXDIR)/*.def

--- a/build/win64/Makefile
+++ b/build/win64/Makefile
@@ -70,25 +70,52 @@ $(JSONDIRB)/%.o: $(JSONDIRB)/%.c
 	$(CC) $(CFLAGS) $(INCLUDE_JSON) -c $< -o $@
 
 install_max:
-	@if [ -z "$(DSTDIR)" ]; \
-	then echo "Usage: make install_max DSTDIR=<installation_path>"; \
-	elif [ ! -d "$(DSTDIR)" ]; \
-	then echo "Error: installation path does not exist or is not a directory"; \
-	else mkdir -p "${DSTDIR}/Sound Design Toolkit/"{externals,support} && \
-	     cp -a $(MAXPACKDIR)/* "${DSTDIR}/Sound Design Toolkit/" && \
-	     cp -a $(SDTDIR)/libSDT.dll "${DSTDIR}/Sound Design Toolkit/support" && \
-	     cp -a $(MAXDIR)/*.mxe64 "${DSTDIR}/Sound Design Toolkit/externals" && \
-	     echo "Sound Design Toolkit 'package for Max' installed in $(DSTDIR)"; \
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make install_max DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		mkdir -p "${DSTDIR}/Sound Design Toolkit/"{externals,support} && \
+		cp -a $(MAXPACKDIR)/* "${DSTDIR}/Sound Design Toolkit/" && \
+		cp -a $(SDTDIR)/libSDT.dll "${DSTDIR}/Sound Design Toolkit/support" && \
+		cp -a $(MAXDIR)/*.mxe64 "${DSTDIR}/Sound Design Toolkit/externals" && \
+		echo "Sound Design Toolkit package for Max installed in '${DSTDIR}/Sound Design Toolkit'"; \
+	fi
+
+uninstall_max:
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make uninstall_max DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		rm -rf "${DSTDIR}/Sound Design Toolkit/" && \
+		echo "Sound Design Toolkit package for Max removed from '${DSTDIR}/Sound Design Toolkit'"; \
 	fi
 
 install_core:
-	@if [ -z "$(DSTDIR)" ]; \
-		then echo "Usage: make install_core DSTDIR=<installation_path>"; \
-		elif [ ! -d "$(DSTDIR)" ]; \
-		then echo "Error: installation path does not exist or is not a directory"; \
-	else mkdir -p "$(DSTDIR)"/SDT && \
-		cp -a $(SDTDIR)/libSDT.dll "$(DSTDIR)"/SDT && \
-		echo "Sound Design Toolkit 'core library' installed in $(DSTDIR)"; \
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make install_core DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		mkdir -p "$(DSTDIR)"/include/SDT && \
+		mkdir -p "$(DSTDIR)"/lib && \
+		cp -a $(SDTDIR)/libSDT.dll "$(DSTDIR)"/lib && \
+		cp -a $(SDTDIR)/*.h $(DSTDIR)/include/SDT && \
+		cp -a $(JSONDIRP)/*.h $(DSTDIR)/include/SDT && \
+		cp -a $(JSONDIRB)/*.h $(DSTDIR)/include/SDT && \
+		echo "Sound Design Toolkit 'Core Library' installed in '$(DSTDIR)'"; \
+	fi
+
+uninstall_core:
+	@if [ -z "$(DSTDIR)" ]; then \
+		echo "Usage: make uninstall_core DSTDIR=<installation_path>"; \
+	elif [ ! -d "$(DSTDIR)" ]; then \
+		echo "Error: installation path does not exist or is not a directory"; \
+	else \
+		rm -rf "$(DSTDIR)"/include/SDT && \
+		rm -f "$(DSTDIR)"/lib/libSDT.dll && \
+		echo "Sound Design Toolkit 'Core Library' removed from '$(DSTDIR)/SDT'"; \
 	fi
 
 clean:

--- a/src/SDT/SDTCommon.h
+++ b/src/SDT/SDTCommon.h
@@ -76,7 +76,7 @@ SDTCommon.h should always be included when using other SDT modules.
 #define SDT_COMMON_H
 
 /** @brief SDT version number */
-#define SDT_ver          081
+#define SDT_ver          082
 /** @brief Value of Pi */
 #define SDT_PI           3.141592653589793
 /** @brief Value of 2 * Pi */


### PR DESCRIPTION
Refactored Makefiles:
   - include headers in all core library distributions
   - pd distribution for linux independent of external .so
   - uninstall recipe conterparts for all install recipes
   -  change dll name for win64 to allow both dlls on the same system